### PR TITLE
Don't let Go update the toolchain

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    env:
+      GOTOOLCHAIN: local
     strategy:
       matrix:
         go: [ stable, oldstable ]

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lstoll/keychain
 
-go 1.23.2
+go 1.22
 
 require github.com/ebitengine/purego v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lstoll/keychain
 
 go 1.23.2
 
-require github.com/ebitengine/purego v0.8.1 // indirect
+require github.com/ebitengine/purego v0.8.1


### PR DESCRIPTION
The GitHub action allows for auto toolchain updates, which defeats the intent of the `oldstable` build. Stop this, set the module to 1.22